### PR TITLE
最新のお知らせが改行されている修正 #70

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -85,7 +85,7 @@ export default {
 
   &-item {
     &-anchor {
-      display: inline-flex;
+      display: inline-block;
       text-decoration: none;
       margin: 5px;
       font-size: 14px;


### PR DESCRIPTION
#70 の最新のお知らせが改行されている のを修正

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #70 

## 📝 関連する issue / Related Issues
- #0
- #0

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- WhatsNew.vueの.WhatsNew .WhatsNew-listクラスを修正  (
&-item内の&-anchor)
  `display: inline-flex;` ⇒ `display: inline-block;`


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/44024424/76937678-9b21f380-6938-11ea-9c2d-cf2348d96b44.png)
