### PR TITLE
検査陽性者の状況カードの更新日時をデータ更新日にする

### DIFF
--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -3,18 +3,22 @@
     <data-view
       :title="$t('検査陽性者の状況')"
       :title-id="'details-of-confirmed-cases'"
-      :date="updatedAt"
+      :date="Data.inspections_summary.date"
     >
       <template v-slot:description>
         <ul>
           <li>
             {{
-              $t('（注）熊本県内において疑い例または患者の濃厚接触者として検査を行ったものについて掲載')
+              $t(
+                '（注）熊本県内において疑い例または患者の濃厚接触者として検査を行ったものについて掲載'
+              )
             }}
           </li>
           <li>
             {{
-              $t('検査実施人数は、速報値として公開するものであり、後日確定データとして修正される場合があります')
+              $t(
+                '検査実施人数は、速報値として公開するものであり、後日確定データとして修正される場合があります'
+              )
             }}
           </li>
         </ul>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #195

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- タイトル通り。
- マージ前の入手元に戻す

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
