### PR TITLE
Twitterシェア時に東京都の文字でツイートされないように

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -302,7 +302,7 @@ export default Vue.extend({
         'https://twitter.com/intent/tweet?text=' +
         this.title +
         ' / ' +
-        this.$t('東京都') +
+        this.$t('熊本県') +
         this.$t('新型コロナウイルス感染症') +
         this.$t('対策サイト') +
         '&url=' +


### PR DESCRIPTION
あとで書く